### PR TITLE
PHPAPI-16 : PHP SDK does not works if in 'Linked select' custom field, child option is not available for the specified value.

### DIFF
--- a/kyCustomFieldDefinition.php
+++ b/kyCustomFieldDefinition.php
@@ -401,7 +401,7 @@ class kyCustomFieldDefinition extends kyObjectBase {
 	public function getOptionById($id) {
 		foreach ($this->getOptions() as $field_option) {
 			/* @var $field_option kyCustomFieldOption */
-			if ($field_option->getId() == $id)
+			if ($field_option->getId() == $id || $id == '0')
 				return $field_option;
 		}
 

--- a/kyCustomFieldOption.php
+++ b/kyCustomFieldOption.php
@@ -62,8 +62,6 @@ class kyCustomFieldOption extends kyObjectBase {
 		$this->display_order = $data['_attributes']['displayorder'];
 		$this->is_selected = intval($data['_attributes']['isselected']) === 0 ? false : true;
 		$this->parent_option_id = intval($data['_attributes']['parentcustomfieldoptionid']);
-		if ($this->parent_option_id === 0)
-			$this->parent_option_id = null;
 	}
 
 	static public function get($id) {


### PR DESCRIPTION
BACKGROUND: While updating custom field value of a linked select field without the child option, the following error gets generated : 
Fatal error: Call to a member function getValue() on a non-object in kyCustomFieldLinkedSelect.php on line 57

Signed-off-by: Saloni Dhall <saloni.dhall@kayako.com>