### PR TITLE
error handling for ticket with no posts, permit array of status id in li...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "curvedental/php-api-library",
+    "name": "kayako/php-api-library",
     "description": "PHP API library for Kayako",
     "require": {
         "php": ">=5.3.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kayako/php-api-library",
+    "name": "curvedental/php-api-library",
     "description": "PHP API library for Kayako",
     "require": {
         "php": ">=5.3.0",

--- a/kyTicket.php
+++ b/kyTicket.php
@@ -581,8 +581,14 @@ class kyTicket extends kyObjectWithCustomFieldsBase {
 		 */
 		if (array_key_exists('posts', $data)) {
 			$this->posts = array();
-			foreach ($data['posts'][0]['post'] as $post_data) {
-				$this->posts[] = new kyTicketPost($post_data);
+			// This is a change from the Kayako PHP library on GitHub.  We
+			// may have tickets with no posts due to migration from NetSuite
+			// which violates the data model for Kayako.  Added an if statement
+			// here to handle this situation.
+			if (is_array($data['posts']) && count($data['posts']) > 0) {
+				foreach ($data['posts'][0]['post'] as $post_data) {
+					$this->posts[] = new kyTicketPost($post_data);
+				}
 			}
 		}
 	}
@@ -668,6 +674,8 @@ class kyTicket extends kyObjectWithCustomFieldsBase {
 			$ticket_status_ids = array($ticket_statuses->getId());
 		} elseif ($ticket_statuses instanceof kyResultSet) {
 			$ticket_status_ids = $ticket_statuses->collectId();
+		} elseif (is_array($ticket_statuses)) {
+			$ticket_status_ids = $ticket_statuses;
 		}
 
 		$owner_staff_ids = array();


### PR DESCRIPTION
Fixed one bug where passing an array of ticket_statuses into getAll had no effect despite the method argument default to type array.

Also one bit of defensive coding to prevent a crash when a ticket has no posts, something which is an artefact of some data migration we did.