### PR TITLE
Allow paginating tickets starting from index 0 instead of minimum 1

### DIFF
--- a/kyTicket.php
+++ b/kyTicket.php
@@ -712,7 +712,7 @@ class kyTicket extends kyObjectWithCustomFieldsBase {
 		else
 			$search_parameters[] = '-1';
 
-		if (is_numeric($starting_ticket_id) && $starting_ticket_id > 0) {
+		if (is_numeric($starting_ticket_id) && !is_null($starting_ticket_id)) {
 			if (!is_numeric($max_items) || $max_items <= 0) {
 				$max_items = 1000;
 			}


### PR DESCRIPTION
Currently `$starting_ticket_id` should be greater than 0, which prohibits selecting the first ticket. This variable should probably be renamed from `$starting_ticket_id` to `$rowOffset` as well.